### PR TITLE
Support k8s 1.22.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 #  SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.14.6-alpine AS build_deps
+FROM golang:1.18.3-alpine AS build_deps
 
 RUN apk add --no-cache git
 
@@ -20,7 +20,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 go build -o webhook -ldflags '-w -extldflags "-static"' .
 
-FROM alpine:3.9
+FROM alpine:3.16
 
 RUN apk add --no-cache ca-certificates
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This guide assumes that the [cert-manager](https://github.com/jetstack/cert-mana
 
 These are important parameters of the `values.yaml` file you should have a look at:
 
-- `groupName` and `solverName`: Together these two form a unique identifier for your solver deployment. `groupName` should be a unique API group name (the creators of cert-manager advise to set it to your company's domain). `solverName` is expected to be unique within all solver deployments that share a `groupName` and can be used to differentiate between them. 
+- `groupName` and `solverName`: Together these two form a unique identifier for your solver deployment. `groupName` should be a unique API group name (the creators of cert-manager advise to set it to your company's domain). `solverName` is expected to be unique within all solver deployments that share a `groupName` and can be used to differentiate between them.
 
 - `certManager.namespace`: The namespace in which cert-manager is deployed.
 
@@ -27,7 +27,7 @@ These are important parameters of the `values.yaml` file you should have a look 
 
 - `verbose`: You can set this value to change the verbosity level of the solver logs. If not specified, it defaults to `2`.
 
-The solver is actually a small API service. It gets a `POST` request from the cert-manager when a TXT record (for the `DNS01` validation) needs to be created, extracts the necessary information from the JSON object that comes with the request and creates a `DNSEntry` object out of it. This object is picked up by the dns-controller-manager, which creates the TXT record. Once the existence of the TXT record has been validated, cert-manager sends another request to the solver, indicating that the record is no longer needed. The solver deletes the corresponding `DNSEntry` object, which in turn triggers the dns-controller-manager to delete the TXT record. 
+The solver is actually a small API service. It gets a `POST` request from the cert-manager when a TXT record (for the `DNS01` validation) needs to be created, extracts the necessary information from the JSON object that comes with the request and creates a `DNSEntry` object out of it. This object is picked up by the dns-controller-manager, which creates the TXT record. Once the existence of the TXT record has been validated, cert-manager sends another request to the solver, indicating that the record is no longer needed. The solver deletes the corresponding `DNSEntry` object, which in turn triggers the dns-controller-manager to delete the TXT record.
 
 
 ### Configure the Issuer
@@ -35,7 +35,7 @@ The solver is actually a small API service. It gets a `POST` request from the ce
 To connect the cert-manager to the solver, a specifically configured `Issuer` (or `ClusterIssuer`) is needed. It should look something like this:
 
 ```yaml
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: my-issuer
@@ -56,7 +56,7 @@ spec:
               ttl: 300
 ```
 
-Only the `webhook` part of the manifest is explained here, see the [official cert-manager documentation](https://docs.cert-manager.io) for more information on issuers (and specifically [ACME issuers](https://docs.cert-manager.io/en/master/tasks/issuers/setup-acme/index.html)). 
+Only the `webhook` part of the manifest is explained here, see the [official cert-manager documentation](https://docs.cert-manager.io) for more information on issuers (and specifically [ACME issuers](https://docs.cert-manager.io/en/master/tasks/issuers/setup-acme/index.html)).
 
 - `groupName` and `solverName`: The values here must match the corresponding values from the solver helm chart, so cert-manager knows where to send the `POST` request to.
 - `config`: Here, some solver-specific configuration can be provided.

--- a/charts/certificate-dns-bridge/templates/apiservice.yaml
+++ b/charts/certificate-dns-bridge/templates/apiservice.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: v1alpha1.{{ .Values.groupName }}

--- a/charts/certificate-dns-bridge/templates/pki.yaml
+++ b/charts/certificate-dns-bridge/templates/pki.yaml
@@ -5,7 +5,7 @@
 ---
 # Create a selfsigned Issuer, in order to create a root CA certificate for
 # signing webhook serving certificates
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ include "certificate-dns-bridge.selfSignedIssuer" . }}
@@ -21,7 +21,7 @@ spec:
 ---
 
 # Generate a CA Certificate used to sign certificates for the webhook
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "certificate-dns-bridge.rootCACertificate" . }}
@@ -42,7 +42,7 @@ spec:
 ---
 
 # Create an Issuer that uses the above generated CA certificate to issue certs
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ include "certificate-dns-bridge.rootCAIssuer" . }}
@@ -59,7 +59,7 @@ spec:
 ---
 
 # Finally, generate a serving certificate for the webhook to use
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "certificate-dns-bridge.servingCertificate" . }}

--- a/charts/certificate-dns-bridge/templates/rbac.yaml
+++ b/charts/certificate-dns-bridge/templates/rbac.yaml
@@ -15,7 +15,7 @@ metadata:
 # Grant the webhook permission to read the ConfigMap containing the Kubernetes
 # apiserver's requestheader-ca-certificate.
 # This ConfigMap is automatically created by the Kubernetes apiserver.
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "certificate-dns-bridge.fullname" . }}:webhook-authentication-reader
@@ -37,7 +37,7 @@ subjects:
 ---
 # apiserver gets the auth-delegator role to delegate auth decisions to
 # the core apiserver
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "certificate-dns-bridge.fullname" . }}:auth-delegator
@@ -57,7 +57,7 @@ subjects:
     namespace: {{ .Release.Namespace }}
 ---
 # Grant cert-manager permission to validate using our apiserver
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "certificate-dns-bridge.fullname" . }}:domain-solver
@@ -74,7 +74,7 @@ rules:
     verbs:
       - 'create'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "certificate-dns-bridge.fullname" . }}:domain-solver
@@ -93,7 +93,7 @@ subjects:
     name: {{ .Values.certManager.serviceAccountName }}
     namespace: {{ .Values.certManager.namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "certificate-dns-bridge.fullname" . }}:dns-admin

--- a/charts/certificate-dns-bridge/values.yaml
+++ b/charts/certificate-dns-bridge/values.yaml
@@ -18,7 +18,7 @@ certManager:
 
 image:
   repository: "eu.gcr.io/gardener-project/certificate-dns-bridge"
-  tag: 2.0.0
+  tag: 2.1.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/certificate-dns-bridge
 
-go 1.12
+go 1.18
 
 require (
 	github.com/gardener/external-dns-management v0.7.13


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the helm chart resources to versions which are compatible with Kubernetes 1.22.x


**Which issue(s) this PR fixes**:
Fixes #7 
Support for https://github.com/gardener/garden-setup/issues/813 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
* Bump Cert Manager resource versions to K8s 1.22.x compatible ones
* Update RBAC api versions to ensure compatibility with K8s 1.22.x
* Update builder and base image to recent versions
```
